### PR TITLE
feat: repo clone infra, file detection

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -4,12 +4,14 @@ import express, { type Express } from 'express';
 import helmet from 'helmet';
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
+import fs from 'fs/promises';
 import { pool } from './db/index.js';
 import { redis } from './db/redis.js';
 import authRouter from './routes/auth.js';
 import scanRouter, { batchRouter } from './routes/scans.js';
 
 const app: Express = express();
+const MIN_READY_DISK_BYTES = 5 * 1024 * 1024 * 1024;
 
 app.set('trust proxy', 1);
 
@@ -43,7 +45,9 @@ app.get('/health/ready', async (_req, res) => {
   const services: Record<string, 'ok' | 'error'> = {
     database: 'error',
     redis: 'error',
+    disk: 'error',
   };
+  let diskFreeMb = 0;
 
   try {
     const client = await pool.connect();
@@ -64,11 +68,26 @@ app.get('/health/ready', async (_req, res) => {
     // services.redis remains 'error'
   }
 
+  try {
+    const { bavail, bsize } = await fs.statfs('/tmp');
+    const freeBytes = bavail * bsize;
+    diskFreeMb = Math.round(freeBytes / 1024 / 1024);
+    if (freeBytes >= MIN_READY_DISK_BYTES) {
+      services.disk = 'ok';
+    }
+  } catch {
+    // services.disk remains 'error'
+  }
+
   const allHealthy = Object.values(services).every((s) => s === 'ok');
 
   res.status(allHealthy ? 200 : 503).json({
     status: allHealthy ? 'ok' : 'degraded',
     services,
+    disk: {
+      freeMb: diskFreeMb,
+      minRequiredMb: Math.round(MIN_READY_DISK_BYTES / 1024 / 1024),
+    },
   });
 });
 

--- a/apps/api/src/scanner/applicability.ts
+++ b/apps/api/src/scanner/applicability.ts
@@ -1,0 +1,50 @@
+// exports getCategoryApplicability for scan-processor.ts
+
+import type { FileManifest } from './detect-files.js';
+
+// mirrors the 13 CHECK constraint values from the scan_categories schema
+export type ScanCategoryName =
+  | 'repository_overview'
+  | 'maintenance_community'
+  | 'documentation_standards'
+  | 'security_vulnerabilities'
+  | 'exposed_secrets'
+  | 'repo_security_posture'
+  | 'dependency_health'
+  | 'code_quality'
+  | 'cicd_devops'
+  | 'workflow_security'
+  | 'iac_security'
+  | 'dockerfile_best_practices'
+  | 'container_security';
+
+export type CategoryApplicability = Record<ScanCategoryName, boolean>;
+
+/**
+ * determines which of the 13 scan categories apply to a given repo
+ * based on the files present. false = N/A, true = applicable.
+ *
+ * always-applicable categories are never skipped regardless of file contents.
+ * conditional categories are skipped when the relevant files are absent,
+ * since running those tools would produce meaningless scores.
+ */
+export function getCategoryApplicability(manifest: FileManifest): CategoryApplicability {
+  return {
+    // always applicable
+    repository_overview: true,
+    maintenance_community: true,
+    documentation_standards: true,
+    security_vulnerabilities: true,
+    exposed_secrets: true,
+    repo_security_posture: true,
+
+    // conditional
+    dependency_health: manifest.hasLockFiles,
+    code_quality: manifest.supportedLanguageFiles > 0,
+    cicd_devops: manifest.hasCIConfig,
+    workflow_security: manifest.hasWorkflowFiles,
+    iac_security: manifest.hasIaCFiles,
+    dockerfile_best_practices: manifest.hasDockerfile,
+    container_security: manifest.hasDockerfile || manifest.hasDockerCompose,
+  };
+}

--- a/apps/api/src/scanner/applicability.ts
+++ b/apps/api/src/scanner/applicability.ts
@@ -1,22 +1,9 @@
 // exports getCategoryApplicability for scan-processor.ts
 
+import type { SCAN_CATEGORY_NAMES } from '../db/schema.js';
 import type { FileManifest } from './detect-files.js';
 
-// mirrors the 13 CHECK constraint values from the scan_categories schema
-export type ScanCategoryName =
-  | 'repository_overview'
-  | 'maintenance_community'
-  | 'documentation_standards'
-  | 'security_vulnerabilities'
-  | 'exposed_secrets'
-  | 'repo_security_posture'
-  | 'dependency_health'
-  | 'code_quality'
-  | 'cicd_devops'
-  | 'workflow_security'
-  | 'iac_security'
-  | 'dockerfile_best_practices'
-  | 'container_security';
+export type ScanCategoryName = (typeof SCAN_CATEGORY_NAMES)[number];
 
 export type CategoryApplicability = Record<ScanCategoryName, boolean>;
 

--- a/apps/api/src/scanner/cleanup.ts
+++ b/apps/api/src/scanner/cleanup.ts
@@ -1,0 +1,14 @@
+// exports cleanupRepo for scan-processor.ts
+
+import fs from 'fs/promises';
+
+const SCAN_DIR_PREFIX = '/tmp/gitagrip-scan-';
+
+export async function cleanupRepo(dirPath: string): Promise<void> {
+  if (!dirPath.startsWith(SCAN_DIR_PREFIX)) {
+    console.warn(`cleanup refused: path is outside allowed prefix — ${dirPath}`);
+    return;
+  }
+
+  await fs.rm(dirPath, { recursive: true, force: true });
+}

--- a/apps/api/src/scanner/cleanup.ts
+++ b/apps/api/src/scanner/cleanup.ts
@@ -10,5 +10,5 @@ export async function cleanupRepo(dirPath: string): Promise<void> {
     return;
   }
 
-  await fs.rm(dirPath, { recursive: true, force: true });
+  await fs.rm(dirPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
 }

--- a/apps/api/src/scanner/clone.ts
+++ b/apps/api/src/scanner/clone.ts
@@ -2,6 +2,7 @@
 
 import { execFile as execFileCb } from 'child_process';
 import { promisify } from 'util';
+import path from 'path';
 import fs from 'fs/promises';
 import { UnrecoverableError } from 'bullmq';
 import { db } from '../db/index.js';
@@ -68,6 +69,8 @@ export async function cloneRepo(
       'git',
       [
         'clone',
+        '-c',
+        'core.symlinks=false',
         '--depth=1',
         '--single-branch',
         `--branch=${defaultBranch}`,
@@ -79,7 +82,12 @@ export async function cloneRepo(
       { timeout: CLONE_TIMEOUT_MS },
     );
   } catch (err: unknown) {
-    const e = err as { killed?: boolean; code?: number | string; message?: string };
+    const e = err as {
+      killed?: boolean;
+      code?: number | string;
+      stderr?: string;
+      message?: string;
+    };
 
     if (e.killed) {
       throw new Error(
@@ -88,8 +96,27 @@ export async function cloneRepo(
       );
     }
 
+    // git binary not installed — code is the string 'ENOENT', not a number
+    if (e.code === 'ENOENT') {
+      throw new Error('git is not installed or not in PATH', { cause: err });
+    }
+
+    // git fatal errors all exit 128 — parse stderr for specific failure reason.
+    // more specific checks first since e.g. "remote branch not found" also contains "not found"
     if (e.code === 128) {
-      throw new UnrecoverableError(`Repository not found: ${repoOwner}/${repoName}`);
+      const stderr = (e.stderr ?? '').toLowerCase();
+
+      if (stderr.includes('remote branch') && stderr.includes('not found')) {
+        throw new UnrecoverableError(
+          `Branch '${defaultBranch}' not found in ${repoOwner}/${repoName}`,
+        );
+      }
+      if (stderr.includes('authentication') || stderr.includes('could not read username')) {
+        throw new UnrecoverableError(`Authentication failed for ${repoOwner}/${repoName}`);
+      }
+      if (stderr.includes('not found') || stderr.includes('does not exist')) {
+        throw new UnrecoverableError(`Repository not found: ${repoOwner}/${repoName}`);
+      }
     }
 
     throw new Error(`Clone failed for ${repoOwner}/${repoName}: ${e.message}`, { cause: err });
@@ -100,20 +127,50 @@ export async function cloneRepo(
   return destDir;
 }
 
-// symlinks in a cloned repo can point anywhere on the host filesystem.
-// tools like trivy and opengrep follow them by default, so we remove them upfront.
+// defense-in-depth: walk the tree manually with opendir + lstat so we never
+// follow directory symlinks (fs.readdir recursive does). core.symlinks=false
+// already prevents real symlinks, but a post-clone sweep catches edge cases.
 async function removeSymlinks(dirPath: string): Promise<void> {
-  const entries = await fs.readdir(dirPath, { recursive: true });
   let removed = 0;
 
-  for (const entry of entries) {
-    const fullPath = `${dirPath}/${entry}`;
-    const stat = await fs.lstat(fullPath);
-    if (stat.isSymbolicLink()) {
-      await fs.unlink(fullPath);
-      removed++;
+  async function walk(dir: string): Promise<void> {
+    let handle;
+    try {
+      handle = await fs.opendir(dir);
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+      throw err;
+    }
+
+    try {
+      for await (const entry of handle) {
+        const fullPath = path.join(dir, entry.name);
+        let stats;
+        try {
+          stats = await fs.lstat(fullPath);
+        } catch (err: unknown) {
+          if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+          throw err;
+        }
+
+        if (stats.isSymbolicLink()) {
+          try {
+            await fs.unlink(fullPath);
+            removed++;
+          } catch (err: unknown) {
+            if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+          }
+        } else if (stats.isDirectory()) {
+          await walk(fullPath);
+        }
+      }
+    } finally {
+      // opendir handle is auto-closed by the for-await loop, but if we
+      // break out early due to an error the finally ensures cleanup
     }
   }
+
+  await walk(dirPath);
 
   if (removed > 0) {
     console.warn(`[clone] removed ${removed} symlink(s) from ${dirPath}`);

--- a/apps/api/src/scanner/clone.ts
+++ b/apps/api/src/scanner/clone.ts
@@ -1,0 +1,121 @@
+// runs git clone on a repo and saves the clone to a temporary directory, exports cloneRepo for scan-processor.ts
+
+import { execFile as execFileCb } from 'child_process';
+import { promisify } from 'util';
+import fs from 'fs/promises';
+import { UnrecoverableError } from 'bullmq';
+import { db } from '../db/index.js';
+import { scans } from '../db/schema.js';
+import { eq } from 'drizzle-orm';
+
+const execFile = promisify(execFileCb);
+
+// 2 gb limit
+const MAX_REPO_SIZE_KB = 2_097_152;
+const CLONE_TIMEOUT_MS = 120_000;
+// 5 gb minimum free space on /tmp before we attempt a clone
+const MIN_FREE_DISK_BYTES = 5 * 1024 * 1024 * 1024;
+
+// only allow safe characters in owner/repo names before interpolating into the url
+const SAFE_NAME = /^[a-zA-Z0-9._-]+$/;
+
+export async function cloneRepo(
+  repoOwner: string,
+  repoName: string,
+  scanId: string,
+  defaultBranch: string,
+  sizeKb: number,
+): Promise<string> {
+  if (!SAFE_NAME.test(repoOwner) || !SAFE_NAME.test(repoName)) {
+    throw new UnrecoverableError(`Invalid repo owner or name: ${repoOwner}/${repoName}`);
+  }
+
+  // check size before we even attempt the clone
+  if (sizeKb > MAX_REPO_SIZE_KB) {
+    await db
+      .update(scans)
+      .set({ status: 'failed', errorMessage: 'Repository exceeds 2 GB size limit' })
+      .where(eq(scans.id, scanId));
+    throw new UnrecoverableError('Repository exceeds 2 GB size limit');
+  }
+
+  if (sizeKb > 512_000) {
+    console.warn(
+      `[clone] large repo warning: ${repoOwner}/${repoName} is ${Math.round(sizeKb / 1024)} MB`,
+    );
+  }
+
+  // check available disk space on /tmp before cloning
+  const { bavail, bsize } = await fs.statfs('/tmp');
+  const freeDiskBytes = bavail * bsize;
+
+  if (freeDiskBytes < MIN_FREE_DISK_BYTES) {
+    console.error(
+      `[clone] insufficient disk space: ${Math.round((freeDiskBytes / 1024 / 1024 / 1024) * 10) / 10} GB free`,
+    );
+    await db
+      .update(scans)
+      .set({ status: 'failed', errorMessage: 'Insufficient disk space' })
+      .where(eq(scans.id, scanId));
+    throw new UnrecoverableError('Insufficient disk space');
+  }
+
+  const cloneUrl = `https://github.com/${repoOwner}/${repoName}.git`;
+  const destDir = `/tmp/gitagrip-scan-${scanId}`;
+
+  try {
+    await execFile(
+      'git',
+      [
+        'clone',
+        '--depth=1',
+        '--single-branch',
+        `--branch=${defaultBranch}`,
+        '--quiet',
+        '--no-recurse-submodules',
+        cloneUrl,
+        destDir,
+      ],
+      { timeout: CLONE_TIMEOUT_MS },
+    );
+  } catch (err: unknown) {
+    const e = err as { killed?: boolean; code?: number | string; message?: string };
+
+    if (e.killed) {
+      throw new Error(
+        `Clone timed out after ${CLONE_TIMEOUT_MS / 1000}s for ${repoOwner}/${repoName}`,
+        { cause: err },
+      );
+    }
+
+    if (e.code === 128) {
+      throw new UnrecoverableError(`Repository not found: ${repoOwner}/${repoName}`);
+    }
+
+    throw new Error(`Clone failed for ${repoOwner}/${repoName}: ${e.message}`, { cause: err });
+  }
+
+  await removeSymlinks(destDir);
+
+  return destDir;
+}
+
+// symlinks in a cloned repo can point anywhere on the host filesystem.
+// tools like trivy and opengrep follow them by default, so we remove them upfront.
+async function removeSymlinks(dirPath: string): Promise<void> {
+  const entries = await fs.readdir(dirPath, { recursive: true });
+  let removed = 0;
+
+  for (const entry of entries) {
+    const fullPath = `${dirPath}/${entry}`;
+    const stat = await fs.lstat(fullPath);
+    if (stat.isSymbolicLink()) {
+      await fs.unlink(fullPath);
+      removed++;
+    }
+  }
+
+  if (removed > 0) {
+    console.warn(`[clone] removed ${removed} symlink(s) from ${dirPath}`);
+  }
+}

--- a/apps/api/src/scanner/detect-files.ts
+++ b/apps/api/src/scanner/detect-files.ts
@@ -1,0 +1,157 @@
+// extracts files from clone in temp directory as a list, exports detectFiles for scan-processor.ts
+
+import { readdir, stat } from 'fs/promises';
+import path from 'path';
+
+export interface FileManifest {
+  hasDockerfile: boolean;
+  hasDockerCompose: boolean;
+  hasIaCFiles: boolean;
+  hasLockFiles: boolean;
+  hasCIConfig: boolean;
+  hasWorkflowFiles: boolean;
+  hasReadme: boolean;
+  hasLicense: boolean;
+  hasContributing: boolean;
+  hasChangelog: boolean;
+  hasCodeOfConduct: boolean;
+  hasSecurityPolicy: boolean;
+  supportedLanguageFiles: number;
+  totalFiles: number;
+  totalSizeKb: number;
+}
+
+// extensions we consider "real source code" for code quality scoring
+const SUPPORTED_LANGUAGE_EXTENSIONS = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.py',
+  '.rb',
+  '.go',
+  '.rs',
+  '.java',
+  '.kt',
+  '.swift',
+  '.cpp',
+  '.c',
+  '.cs',
+  '.php',
+]);
+
+const LOCK_FILES = new Set([
+  'package-lock.json',
+  'yarn.lock',
+  'pnpm-lock.yaml',
+  'go.sum',
+  'Cargo.lock',
+  'Gemfile.lock',
+  'requirements.txt',
+  'poetry.lock',
+  'composer.lock',
+  'pubspec.lock',
+  'Pipfile.lock',
+]);
+
+const DOCKERFILE_PATTERN = /^(dockerfile|.*\.dockerfile)$/i;
+const DOCKER_COMPOSE_PATTERN = /^(docker-compose|compose)(\..*)?\.ya?ml$/i;
+
+// iac: terraform, cloudformation, k8s manifests
+const IAC_PATTERN = /\.(tf|tfvars)$|cloudformation.*\.ya?ml$|^(k8s|kubernetes|manifests)\//i;
+
+const CI_FILES = new Set(['Jenkinsfile', '.gitlab-ci.yml']);
+const CI_DIRS = ['.github/workflows', '.circleci'];
+
+export async function detectFiles(repoDir: string): Promise<FileManifest> {
+  const entries = await readdir(repoDir, { recursive: true });
+
+  // strip the leading repo dir prefix and exclude .git/
+  const files = entries.filter((e) => !e.startsWith('.git/') && e !== '.git');
+
+  const manifest: FileManifest = {
+    hasDockerfile: false,
+    hasDockerCompose: false,
+    hasIaCFiles: false,
+    hasLockFiles: false,
+    hasCIConfig: false,
+    hasWorkflowFiles: false,
+    hasReadme: false,
+    hasLicense: false,
+    hasContributing: false,
+    hasChangelog: false,
+    hasCodeOfConduct: false,
+    hasSecurityPolicy: false,
+    supportedLanguageFiles: 0,
+    totalFiles: 0,
+    totalSizeKb: 0,
+  };
+
+  let totalBytes = 0;
+
+  for (const relativePath of files) {
+    const fullPath = path.join(repoDir, relativePath);
+    const fileName = path.basename(relativePath).toLowerCase();
+    const fileNameRaw = path.basename(relativePath);
+
+    // stat to get size and skip directories
+    let fileStat;
+    try {
+      fileStat = await stat(fullPath);
+    } catch {
+      continue;
+    }
+    if (fileStat.isDirectory()) continue;
+
+    manifest.totalFiles++;
+    totalBytes += fileStat.size;
+
+    // dockerfile
+    if (DOCKERFILE_PATTERN.test(fileNameRaw)) manifest.hasDockerfile = true;
+
+    // docker compose
+    if (DOCKER_COMPOSE_PATTERN.test(fileNameRaw)) manifest.hasDockerCompose = true;
+
+    // iac
+    if (IAC_PATTERN.test(relativePath)) manifest.hasIaCFiles = true;
+
+    // lock files
+    if (LOCK_FILES.has(fileNameRaw)) manifest.hasLockFiles = true;
+
+    // ci config: github actions
+    if (
+      relativePath.startsWith('.github/workflows/') &&
+      (fileName.endsWith('.yml') || fileName.endsWith('.yaml'))
+    ) {
+      manifest.hasCIConfig = true;
+      manifest.hasWorkflowFiles = true;
+    }
+
+    // ci config: other systems
+    if (CI_FILES.has(fileNameRaw)) manifest.hasCIConfig = true;
+    if (CI_DIRS.some((d) => relativePath.startsWith(d + '/'))) manifest.hasCIConfig = true;
+
+    // community/docs files — check top-level and .github/ only
+    const dir = path.dirname(relativePath);
+    const isTopLevelOrGithub = dir === '.' || dir === '.github';
+
+    if (isTopLevelOrGithub) {
+      if (/^readme(\..+)?$/i.test(fileNameRaw)) manifest.hasReadme = true;
+      if (/^license(\..+)?$/i.test(fileNameRaw)) manifest.hasLicense = true;
+      if (/^contributing(\..+)?$/i.test(fileNameRaw)) manifest.hasContributing = true;
+      if (/^changelog(\..+)?$/i.test(fileNameRaw)) manifest.hasChangelog = true;
+      if (/^code[-_]?of[-_]?conduct(\..+)?$/i.test(fileNameRaw)) manifest.hasCodeOfConduct = true;
+      if (/^security(\..+)?$/i.test(fileNameRaw)) manifest.hasSecurityPolicy = true;
+    }
+
+    // source code files
+    const ext = path.extname(fileName);
+    if (SUPPORTED_LANGUAGE_EXTENSIONS.has(ext)) manifest.supportedLanguageFiles++;
+  }
+
+  manifest.totalSizeKb = Math.round(totalBytes / 1024);
+
+  return manifest;
+}

--- a/apps/api/src/scanner/detect-files.ts
+++ b/apps/api/src/scanner/detect-files.ts
@@ -1,6 +1,6 @@
 // extracts files from clone in temp directory as a list, exports detectFiles for scan-processor.ts
 
-import { readdir, stat } from 'fs/promises';
+import { readdir, lstat } from 'fs/promises';
 import path from 'path';
 
 export interface FileManifest {
@@ -66,10 +66,7 @@ const CI_FILES = new Set(['Jenkinsfile', '.gitlab-ci.yml']);
 const CI_DIRS = ['.github/workflows', '.circleci'];
 
 export async function detectFiles(repoDir: string): Promise<FileManifest> {
-  const entries = await readdir(repoDir, { recursive: true });
-
-  // strip the leading repo dir prefix and exclude .git/
-  const files = entries.filter((e) => !e.startsWith('.git/') && e !== '.git');
+  const entries = await readdir(repoDir, { recursive: true, withFileTypes: true });
 
   const manifest: FileManifest = {
     hasDockerfile: false,
@@ -91,36 +88,38 @@ export async function detectFiles(repoDir: string): Promise<FileManifest> {
 
   let totalBytes = 0;
 
-  for (const relativePath of files) {
-    const fullPath = path.join(repoDir, relativePath);
-    const fileName = path.basename(relativePath).toLowerCase();
-    const fileNameRaw = path.basename(relativePath);
+  for (const entry of entries) {
+    // skip symlinks entirely — defense-in-depth against traversal attacks
+    if (entry.isSymbolicLink()) continue;
+    if (!entry.isFile()) continue;
 
-    // stat to get size and skip directories
-    let fileStat;
+    const relativePath = path.relative(repoDir, path.join(entry.parentPath, entry.name));
+
+    if (relativePath.startsWith('.git/') || relativePath === '.git') continue;
+
+    const fileNameRaw = entry.name;
+    const fileName = fileNameRaw.toLowerCase();
+
+    // lstat for file size (doesn't follow symlinks)
+    let fileSize: number;
     try {
-      fileStat = await stat(fullPath);
+      const stats = await lstat(path.join(entry.parentPath, entry.name));
+      fileSize = stats.size;
     } catch {
       continue;
     }
-    if (fileStat.isDirectory()) continue;
 
     manifest.totalFiles++;
-    totalBytes += fileStat.size;
+    totalBytes += fileSize;
 
-    // dockerfile
     if (DOCKERFILE_PATTERN.test(fileNameRaw)) manifest.hasDockerfile = true;
 
-    // docker compose
     if (DOCKER_COMPOSE_PATTERN.test(fileNameRaw)) manifest.hasDockerCompose = true;
 
-    // iac
     if (IAC_PATTERN.test(relativePath)) manifest.hasIaCFiles = true;
 
-    // lock files
     if (LOCK_FILES.has(fileNameRaw)) manifest.hasLockFiles = true;
 
-    // ci config: github actions
     if (
       relativePath.startsWith('.github/workflows/') &&
       (fileName.endsWith('.yml') || fileName.endsWith('.yaml'))
@@ -129,11 +128,9 @@ export async function detectFiles(repoDir: string): Promise<FileManifest> {
       manifest.hasWorkflowFiles = true;
     }
 
-    // ci config: other systems
     if (CI_FILES.has(fileNameRaw)) manifest.hasCIConfig = true;
     if (CI_DIRS.some((d) => relativePath.startsWith(d + '/'))) manifest.hasCIConfig = true;
 
-    // community/docs files — check top-level and .github/ only
     const dir = path.dirname(relativePath);
     const isTopLevelOrGithub = dir === '.' || dir === '.github';
 
@@ -146,7 +143,6 @@ export async function detectFiles(repoDir: string): Promise<FileManifest> {
       if (/^security(\..+)?$/i.test(fileNameRaw)) manifest.hasSecurityPolicy = true;
     }
 
-    // source code files
     const ext = path.extname(fileName);
     if (SUPPORTED_LANGUAGE_EXTENSIONS.has(ext)) manifest.supportedLanguageFiles++;
   }

--- a/apps/api/src/scanner/detect-files.ts
+++ b/apps/api/src/scanner/detect-files.ts
@@ -139,9 +139,9 @@ export async function detectFiles(repoDir: string): Promise<FileManifest> {
 
     if (isTopLevelOrGithub) {
       if (/^readme(\..+)?$/i.test(fileNameRaw)) manifest.hasReadme = true;
-      if (/^license(\..+)?$/i.test(fileNameRaw)) manifest.hasLicense = true;
+      if (/^(license|copying)(\..+)?$/i.test(fileNameRaw)) manifest.hasLicense = true;
       if (/^contributing(\..+)?$/i.test(fileNameRaw)) manifest.hasContributing = true;
-      if (/^changelog(\..+)?$/i.test(fileNameRaw)) manifest.hasChangelog = true;
+      if (/^(changelog|changes|history)(\..+)?$/i.test(fileNameRaw)) manifest.hasChangelog = true;
       if (/^code[-_]?of[-_]?conduct(\..+)?$/i.test(fileNameRaw)) manifest.hasCodeOfConduct = true;
       if (/^security(\..+)?$/i.test(fileNameRaw)) manifest.hasSecurityPolicy = true;
     }

--- a/apps/api/src/worker/index.ts
+++ b/apps/api/src/worker/index.ts
@@ -1,15 +1,35 @@
 // creates worker instances for the scan and batch processors (separate from express app)
 
+import fs from 'fs/promises';
 import { Worker, Job } from 'bullmq';
 import { eq, sql } from 'drizzle-orm';
 import { bullRedis } from '../db/bull-redis.js';
 import { db } from '../db/index.js';
 import { scans, scanBatches } from '../db/schema.js';
 import { scanQueue } from '../queue/scan-queue.js';
+import { cleanupRepo } from '../scanner/cleanup.js';
 
 // determine file extension based on environment
 const isProd = process.env.NODE_ENV === 'production';
 const ext = isProd ? '.js' : '.ts';
+const SCAN_DIR_NAME_PREFIX = 'gitagrip-scan-';
+
+async function cleanupStaleTempScanDirs(): Promise<void> {
+  const entries = await fs.readdir('/tmp', { withFileTypes: true });
+  const staleDirs = entries
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith(SCAN_DIR_NAME_PREFIX))
+    .map((entry) => `/tmp/${entry.name}`);
+
+  await Promise.all(staleDirs.map((dirPath) => cleanupRepo(dirPath)));
+
+  if (staleDirs.length > 0) {
+    console.log(
+      `[worker] cleaned ${staleDirs.length} stale temp scan director${staleDirs.length === 1 ? 'y' : 'ies'}`,
+    );
+  }
+}
+
+await cleanupStaleTempScanDirs();
 
 // Scan worker
 const scanWorker = new Worker(

--- a/apps/api/src/worker/scan-processor.ts
+++ b/apps/api/src/worker/scan-processor.ts
@@ -9,6 +9,7 @@ import { UnrecoverableError } from 'bullmq';
 import { eq, sql } from 'drizzle-orm';
 import { db } from '../db/index.js';
 import { scans, scanCategories, SCAN_CATEGORY_NAMES } from '../db/schema.js';
+import { cleanupRepo } from '../scanner/cleanup.js';
 
 interface ScanJobData {
   scanId: string;
@@ -27,6 +28,9 @@ function randomInt(min: number, max: number): number {
 
 export default async function scanProcessor(job: Job<ScanJobData>) {
   const { scanId, repoOwner, repoName } = job.data;
+
+  const repoDir = '' as string; // TODO: remove repoDir stub, replace with cloneRepo result
+
   // ** job.data also contains githubRepoId (unused in mock, needed by real scan tools) **
   // add back once scan routes are built
   console.log(`Processing scan ${scanId} for ${repoOwner}/${repoName}`);
@@ -125,5 +129,8 @@ export default async function scanProcessor(job: Job<ScanJobData>) {
     throw err; // Re-throw so BullMQ can retry
   } finally {
     clearTimeout(timeoutId);
+    if (repoDir) {
+      await cleanupRepo(repoDir);
+    }
   }
 }

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts';
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts';
+import './.next/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -12,6 +12,8 @@ FROM base AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 
+RUN apk add --no-cache git
+
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 appuser
 


### PR DESCRIPTION
Closes #11 

- `apps/api/src/scanner/clone.ts`: clones a repo into a temp directory using `git clone`, validates owner/repo names, enforces a 2 GB size limit, removes symlinks after cloning, and handles timeout/not-found/generic failures
- `apps/api/src/scanner/detect-files.ts`: walks the cloned repo directory and builds a manifest of what files are present, used downstream to determine which scan categories are applicable
- `apps/api/src/scanner/applicability.ts`: takes the file manifest and returns which of the 13 categories should be scored vs marked N/A
- `apps/api/src/scanner/cleanup.ts`: deletes the temp directory after a scan finishes, always called in the `finally` block of the scan processor